### PR TITLE
ci: ignore index.tsx in codecov report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+ignore:
+  - "src/index.tsx"
 coverage:
   status:
     patch:


### PR DESCRIPTION
Now, will be 100%.